### PR TITLE
Adding the option to set $ignore_alias on people updates

### DIFF
--- a/lib/Producers/MixpanelPeople.php
+++ b/lib/Producers/MixpanelPeople.php
@@ -14,7 +14,7 @@ class Producers_MixpanelPeople extends Producers_MixpanelBaseProducer {
      * @param null $ip
      * @return array
      */
-    private function _constructPayload($distinct_id, $operation, $value, $ip = null, $ignore_time = false) {
+    private function _constructPayload($distinct_id, $operation, $value, $ip = null, $ignore_time = false, $ignore_alias = false) {
         $payload = array(
             '$token' => $this->_token,
             '$distinct_id' => $distinct_id,
@@ -22,6 +22,7 @@ class Producers_MixpanelPeople extends Producers_MixpanelBaseProducer {
         );
         if ($ip !== null) $payload['$ip'] = $ip;
         if ($ignore_time === true) $payload['$ignore_time'] = true;
+        if ($ignore_alias === true) $payload['$ignore_alias'] = true;
         return $payload;
     }
 
@@ -32,9 +33,10 @@ class Producers_MixpanelPeople extends Producers_MixpanelBaseProducer {
      * @param array $props associative array of properties to set on the profile
      * @param string|null $ip the ip address of the client (used for geo-location)
      * @param boolean $ignore_time If the $ignore_time property is true, Mixpanel will not automatically update the "Last Seen" property of the profile. Otherwise, Mixpanel will add a "Last Seen" property associated with the current time
+     * @param boolean $ignore_alias If the $ignore_alias property is true, an alias look up will not be performed after ingestion. Otherwise, a lookup for the distinct ID will be performed, and replaced if a match is found
      */
-    public function set($distinct_id, $props, $ip = null, $ignore_time = false) {
-        $payload = $this->_constructPayload($distinct_id, '$set', $props, $ip, $ignore_time);
+    public function set($distinct_id, $props, $ip = null, $ignore_time = false, $ignore_alias = false) {
+        $payload = $this->_constructPayload($distinct_id, '$set', $props, $ip, $ignore_time, $ignore_alias);
         $this->enqueue($payload);
     }
 
@@ -45,9 +47,10 @@ class Producers_MixpanelPeople extends Producers_MixpanelBaseProducer {
      * @param array $props associative array of properties to set on the profile
      * @param string|null $ip the ip address of the client (used for geo-location)
      * @param boolean $ignore_time If the $ignore_time property is true, Mixpanel will not automatically update the "Last Seen" property of the profile. Otherwise, Mixpanel will add a "Last Seen" property associated with the current time
+     * @param boolean $ignore_alias If the $ignore_alias property is true, an alias look up will not be performed after ingestion. Otherwise, a lookup for the distinct ID will be performed, and replaced if a match is found     
      */
-    public function setOnce($distinct_id, $props, $ip = null, $ignore_time = false) {
-        $payload = $this->_constructPayload($distinct_id, '$set_once', $props, $ip, $ignore_time);
+    public function setOnce($distinct_id, $props, $ip = null, $ignore_time = false, $ignore_alias = false) {
+        $payload = $this->_constructPayload($distinct_id, '$set_once', $props, $ip, $ignore_time, $ignore_alias);
         $this->enqueue($payload);
     }
 
@@ -59,9 +62,10 @@ class Producers_MixpanelPeople extends Producers_MixpanelBaseProducer {
      * @param array $props associative array of properties to unset on the profile
      * @param string|null $ip the ip address of the client (used for geo-location)
      * @param boolean $ignore_time If the $ignore_time property is true, Mixpanel will not automatically update the "Last Seen" property of the profile. Otherwise, Mixpanel will add a "Last Seen" property associated with the current time
+     * @param boolean $ignore_alias If the $ignore_alias property is true, an alias look up will not be performed after ingestion. Otherwise, a lookup for the distinct ID will be performed, and replaced if a match is found     
      */
-    public function remove($distinct_id, $props, $ip = null, $ignore_time = false) {
-        $payload = $this->_constructPayload($distinct_id, '$unset', $props, $ip, $ignore_time);
+    public function remove($distinct_id, $props, $ip = null, $ignore_time = false, $ignore_alias = false) {
+        $payload = $this->_constructPayload($distinct_id, '$unset', $props, $ip, $ignore_time, $ignore_alias);
         $this->enqueue($payload);
     }
 
@@ -73,9 +77,10 @@ class Producers_MixpanelPeople extends Producers_MixpanelBaseProducer {
      * @param int $val the amount to increment the property by
      * @param string|null $ip the ip address of the client (used for geo-location)
      * @param boolean $ignore_time If the $ignore_time property is true, Mixpanel will not automatically update the "Last Seen" property of the profile. Otherwise, Mixpanel will add a "Last Seen" property associated with the current time
+     * @param boolean $ignore_alias If the $ignore_alias property is true, an alias look up will not be performed after ingestion. Otherwise, a lookup for the distinct ID will be performed, and replaced if a match is found     
      */
-    public function increment($distinct_id, $prop, $val, $ip = null, $ignore_time = false) {
-        $payload = $this->_constructPayload($distinct_id, '$add', array("$prop" => $val), $ip, $ignore_time);
+    public function increment($distinct_id, $prop, $val, $ip = null, $ignore_time = false, $ignore_alias = false) {
+        $payload = $this->_constructPayload($distinct_id, '$add', array("$prop" => $val), $ip, $ignore_time, $ignore_alias);
         $this->enqueue($payload);
     }
 
@@ -87,10 +92,11 @@ class Producers_MixpanelPeople extends Producers_MixpanelBaseProducer {
      * @param string|array $val items to add to the list
      * @param string|null $ip the ip address of the client (used for geo-location)
      * @param boolean $ignore_time If the $ignore_time property is true, Mixpanel will not automatically update the "Last Seen" property of the profile. Otherwise, Mixpanel will add a "Last Seen" property associated with the current time
+     * @param boolean $ignore_alias If the $ignore_alias property is true, an alias look up will not be performed after ingestion. Otherwise, a lookup for the distinct ID will be performed, and replaced if a match is found     
      */
-    public function append($distinct_id, $prop, $val, $ip = null, $ignore_time = false) {
+    public function append($distinct_id, $prop, $val, $ip = null, $ignore_time = false, $ignore_alias = false) {
         $operation = gettype($val) == "array" ? '$union' : '$append';
-        $payload = $this->_constructPayload($distinct_id, $operation, array("$prop" => $val), $ip, $ignore_time);
+        $payload = $this->_constructPayload($distinct_id, $operation, array("$prop" => $val), $ip, $ignore_time, $ignore_alias);
         $this->enqueue($payload);
     }
 
@@ -101,8 +107,9 @@ class Producers_MixpanelPeople extends Producers_MixpanelBaseProducer {
      * @param null $timestamp the timestamp of when the transaction occurred (default to current timestamp)
      * @param string|null $ip the ip address of the client (used for geo-location)
      * @param boolean $ignore_time If the $ignore_time property is true, Mixpanel will not automatically update the "Last Seen" property of the profile. Otherwise, Mixpanel will add a "Last Seen" property associated with the current time
+     * @param boolean $ignore_alias If the $ignore_alias property is true, an alias look up will not be performed after ingestion. Otherwise, a lookup for the distinct ID will be performed, and replaced if a match is found     
      */
-    public function trackCharge($distinct_id, $amount, $timestamp = null, $ip = null, $ignore_time = false) {
+    public function trackCharge($distinct_id, $amount, $timestamp = null, $ip = null, $ignore_time = false, $ignore_alias = false) {
         $timestamp = $timestamp == null ? time() : $timestamp;
         $date_iso = date("c", $timestamp);
         $transaction = array(
@@ -110,7 +117,7 @@ class Producers_MixpanelPeople extends Producers_MixpanelBaseProducer {
             '$amount' => $amount
         );
         $val = array('$transactions' => $transaction);
-        $payload = $this->_constructPayload($distinct_id, '$append', $val, $ip, $ignore_time);
+        $payload = $this->_constructPayload($distinct_id, '$append', $val, $ip, $ignore_time, $ignore_alias);
         $this->enqueue($payload);
     }
 
@@ -119,9 +126,10 @@ class Producers_MixpanelPeople extends Producers_MixpanelBaseProducer {
      * @param string|int $distinct_id the distinct_id or alias of a user
      * @param string|null $ip the ip address of the client (used for geo-location)
      * @param boolean $ignore_time If the $ignore_time property is true, Mixpanel will not automatically update the "Last Seen" property of the profile. Otherwise, Mixpanel will add a "Last Seen" property associated with the current time
+     * @param boolean $ignore_alias If the $ignore_alias property is true, an alias look up will not be performed after ingestion. Otherwise, a lookup for the distinct ID will be performed, and replaced if a match is found     
      */
-    public function clearCharges($distinct_id, $ip = null, $ignore_time = false) {
-        $payload = $this->_constructPayload($distinct_id, '$set', array('$transactions' => array()), $ip, $ignore_time);
+    public function clearCharges($distinct_id, $ip = null, $ignore_time = false, $ignore_alias = false) {
+        $payload = $this->_constructPayload($distinct_id, '$set', array('$transactions' => array()), $ip, $ignore_time, $ignore_alias);
         $this->enqueue($payload);
     }
 
@@ -130,9 +138,10 @@ class Producers_MixpanelPeople extends Producers_MixpanelBaseProducer {
      * @param string|int $distinct_id the distinct_id or alias of a user
      * @param string|null $ip the ip address of the client (used for geo-location)
      * @param boolean $ignore_time If the $ignore_time property is true, Mixpanel will not automatically update the "Last Seen" property of the profile. Otherwise, Mixpanel will add a "Last Seen" property associated with the current time
+     * @param boolean $ignore_alias If the $ignore_alias property is true, an alias look up will not be performed after ingestion. Otherwise, a lookup for the distinct ID will be performed, and replaced if a match is found     
      */
-    public function deleteUser($distinct_id, $ip = null, $ignore_time = false) {
-        $payload = $this->_constructPayload($distinct_id, '$delete', "", $ip, $ignore_time);
+    public function deleteUser($distinct_id, $ip = null, $ignore_time = false, $ignore_alias = false) {
+        $payload = $this->_constructPayload($distinct_id, '$delete', "", $ip, $ignore_time, $ignore_alias);
         $this->enqueue($payload);
     }
 


### PR DESCRIPTION
Including an extra param on people update calls so that the $ignore_alias property can be included
